### PR TITLE
mac-changer as a substitute?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # square
 Small Shell script to help circumvent Disney Circle.
 
+----
+
 ## mac-changer
-After reading this repository, I think mac-changer maybe a better solution for convienance. However kudos to the author and contributors in fork/s.
+
+After reading this repository, I think mac-changer maybe a better solution for convenience. 
+
+However kudos to the author and contributors in fork/s.
 
 https://github.com/lwsnz/mac-changer
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # square
 Small Shell script to help circumvent Disney Circle.
 
+## mac-changer
+After reading this repository, I think mac-changer maybe a better solution for convienance. However kudos to the author and contributors in fork/s.
+
+https://github.com/lwsnz/mac-changer
+
+----
+
 # Support
 
 Right now, this solution only works with macOS and Linux. Linux will need a few adjustments.


### PR DESCRIPTION
Reference to the tool used in GNU / Unix to manipulate MAC addresses.

GNU MAC Changer is an utility that makes the maniputation of MAC addresses of network interfaces easier.
https://github.com/lwsnz/mac-changer